### PR TITLE
Fix async monitoring not running

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from utils.option_utils    import place_bull_spread_with_oco, place_bear_spread_
 from utils.logger import TRADE_LOG_FILE, save_trade_to_log
 from utils.option_utils import get_next_option_expiry
 from utils.trade_utils import is_market_hours
+from utils.async_runner import start_background_loop
 ACCOUNT_VALUE = 100000
 def is_time_between(start, end):
     now = datetime.now().time()
@@ -172,6 +173,8 @@ def resume_monitoring_open_trades(ib, trade_log_callback=None):
             )
 
 def main():
+    # Start asyncio loop in background so monitor_stop_trigger coroutines run
+    start_background_loop()
     if is_dry_run():
         print("🧪 Dry run mode — weekend detected. No trades will be placed.")
         return

--- a/utils/async_runner.py
+++ b/utils/async_runner.py
@@ -1,0 +1,20 @@
+import asyncio
+import threading
+
+_loop = asyncio.new_event_loop()
+
+
+def _run_loop(loop: asyncio.AbstractEventLoop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+def start_background_loop():
+    """Start the global asyncio event loop in a background thread."""
+    thread = threading.Thread(target=_run_loop, args=(_loop,), daemon=True)
+    thread.start()
+
+
+def get_loop() -> asyncio.AbstractEventLoop:
+    """Return the global asyncio event loop instance."""
+    return _loop

--- a/utils/option_utils.py
+++ b/utils/option_utils.py
@@ -2,8 +2,9 @@ from ib_insync import Option, Contract, ComboLeg, Order, Stock
 import numpy as np
 import asyncio
 from datetime import datetime, date
-import time 
+import time
 from ib_insync import LimitOrder
+from utils.async_runner import get_loop
 
 def clean_magic_numbers(order):
     # Required fields for a basic order that must not be None:
@@ -275,8 +276,8 @@ def place_bear_spread_with_oco(ib, symbol, strike_pair, expiry, account_value, t
             await asyncio.sleep(60)
 
     import asyncio
-    loop = asyncio.get_event_loop()
-    loop.create_task(monitor_stop_trigger())
+    loop = get_loop()
+    asyncio.run_coroutine_threadsafe(monitor_stop_trigger(), loop)
 
     return {
         "spread": f"{symbol}_{sell_strike}_{buy_strike}_{expiry}",
@@ -542,8 +543,8 @@ def place_bull_spread_with_oco(ib, symbol, strike_pair, expiry, account_value, t
             await asyncio.sleep(60)
 
     import asyncio
-    loop = asyncio.get_event_loop()
-    loop.create_task(monitor_stop_trigger())
+    loop = get_loop()
+    asyncio.run_coroutine_threadsafe(monitor_stop_trigger(), loop)
 
     return {
         "spread": f"{symbol}_{sell_strike}_{buy_strike}_{expiry}",


### PR DESCRIPTION
## Summary
- start a global asyncio loop in a background thread
- schedule monitor coroutines on the global event loop
- bootstrap the loop before trading starts

## Testing
- `pytest -q`
- `python -m py_compile main.py utils/option_utils.py utils/async_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a056cac88326af8a6377e481cbe7