### PR TITLE
Consolidate log_trade_close

### DIFF
--- a/utils/trade_utils.py
+++ b/utils/trade_utils.py
@@ -1,12 +1,10 @@
 import datetime
 import json
 import os
-import numpy as np
-from ib_insync import Stock, Option
+
 from utils.logger import save_trade_to_log
 from utils.option_utils import place_bear_spread_with_oco, place_bull_spread_with_oco
 
-TRADE_LOG_FILE = "trade_log.xlsx"  # or your preferred path/filename
 def log_trade_close(trade, open_price, close_price, quantity, trade_type, status, reason):
     profit = (close_price - open_price) * quantity if trade_type == "bull" else (open_price - close_price) * quantity
     profit_pct = (profit / (open_price * quantity)) * 100 if open_price else 0
@@ -60,24 +58,6 @@ async def resume_monitoring_open_trades(ib, trade_log_callback=None):
                 ib, symbol, (sell_strike, buy_strike), expiry,
                 open_price * quantity, trade_log_callback
             )
-
-def log_trade_close(trade, open_price, close_price, quantity, trade_type, status, reason):
-    profit = (close_price - open_price) * quantity if trade_type == "bull" else (open_price - close_price) * quantity
-    profit_pct = (profit / (open_price * quantity)) * 100 if open_price else 0
-    log_entry = {
-        "date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        "spread": trade.get("spread"),
-        "open_price": open_price,
-        "close_price": close_price,
-        "profit": profit,
-        "profit_pct": profit_pct,
-        "status": status,
-        "close_reason": reason,
-        "quantity": quantity
-    }
-    # Only log closed trades to Excel
-    from utils.excel_utils import save_trade_to_excel
-    save_trade_to_excel(log_entry)
 
 def save_open_trades(trades):
     with open("open_trades.json", "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- deduplicate `log_trade_close` implementation
- drop unused imports and constant from `trade_utils`
- keep single call path for closing trades

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432c79a09c8326ae9304e7466af12b